### PR TITLE
FIX: Alt text lost after performing image manipulations (fixes #6)

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,7 +4,9 @@ Name: asset-alt-text
 SilverStripe\Assets\Image:
   extensions:
     - PurpleSpider\AssetAltText\ImageExtension
-    
+SilverStripe\Assets\Storage\DBFile:
+  extensions:
+    - PurpleSpider\AssetAltText\ImageExtension
 SilverStripe\AssetAdmin\Forms\FileFormFactory:
   extensions:
     - PurpleSpider\AssetAltText\FileFormFactoryExtension

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Asset Alt Text for Silverstripe 4
+# Asset Alt Text for Silverstripe
 
 Adds an alternative text field to Image assets, so that you don't need to use the image `Title` field (which would typically be more succinct than useful alt text).
 


### PR DESCRIPTION
When a manipulation is made, the image is no longer an image and is instead a `DBFile` instance. It’s a really weird distinction, and it seems strange to apply the same extension in multiple places, but other image modules have the same problem:

- https://github.com/jonom/silverstripe-focuspoint/blob/master/_config/config.yml#L6-L8
- https://github.com/WPP-Public/akqa-nz-silverstripe-responsive-images/blob/master/_config/config.yml#L4-L9

